### PR TITLE
Add support for image rendering via host app

### DIFF
--- a/USBInsightHub-A1/UIH-ESP32S3/src/DefaultView.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/DefaultView.cpp
@@ -318,6 +318,8 @@ void defaultScreenFastDataUpdate(){
       if(gState->features.clearScreenText) ScreenArr[i].tProp.numDev = 0;
       ScreenArr[i].tProp.Dev1_Name  = gState->usbInfo[i].Dev1_Name;
       ScreenArr[i].tProp.Dev2_Name  = gState->usbInfo[i].Dev2_Name;
+      ScreenArr[i].tProp.imgBuffer  = gState->usbInfo[i].imgBuffer;
+      ScreenArr[i].tProp.imgBPP     = gState->usbInfo[i].imgBPP;
       ScreenArr[i].tProp.usbType    = gState->usbInfo[i].usbType;
       if(gState->features.clearScreenText) ScreenArr[i].tProp.usbType = 0;      
       ScreenArr[i].pconnected       = gState->features.pcConnected;

--- a/USBInsightHub-A1/UIH-ESP32S3/src/Screen.h
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/Screen.h
@@ -67,6 +67,8 @@ struct txtProp{
   String Dev1_Name;
   String Dev2_Name;
   int usbType;
+  uint8_t imgBPP;
+  uint16_t* imgBuffer;
 };
 
 struct chScreenData { 
@@ -102,6 +104,7 @@ class Screen{
     void screenSetBackLight(int pwm, uint8_t ch);
     void usbIconDraw(uint8_t type, bool active,bool com);
     void flexDevicePrint(String jsonStr, bool pcCon);
+    void imagePrint(uint16_t* imgBuffer, uint8_t bpp, uint32_t color_border);
 
     displayProp dProp[3];
     TFT_eSPI tft       = TFT_eSPI();       // Invoke custom library

--- a/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
@@ -242,6 +242,8 @@ struct USBInfoState {
   String Dev1_Name;
   String Dev2_Name;
   int usbType;
+  uint8_t imgBPP;
+  uint16_t* imgBuffer;
 };
 
 struct BaseMCUStateIn {


### PR DESCRIPTION
This might be considered a little crude. Mostly as JSON requires base64ing the image, which just needs RAM the ESP32 does not have.

Thusly, this works as follows:

To send an image, you have to use a binary protocol: You first send either byte 1, 2 or 3 over the wire (whichever port you wish to update the image for), then the bits per Pixel (4, 8 or 16) as a byte, then you send the whole image data as raw ytes, all 226 by 90 pixels.
You can send 0 BPP for deallocating the image to save RAM.

The ESP32 will acknowledge this with a normal JSON-RPC style response.

This also adds some plumbing/fixes to make this much smoother:
- Add a timeout for host serial communications so that partially sent commands don't linger around. Given images can be large, yeah
- Changes slightly how the colored border around a port is drawn, it is now always in the foreground even in front of images

//EDIT: Managed to get all screens filled with images with WiFi disabled at least!

//EDIT2: And it can even do 16bpp with WiFi off!

//EDIT3: And I fixed the bitmap cutting off the inner rounded corners as well!

But beyond that, here it is :3

![img](https://github.com/user-attachments/assets/ef8b5fa2-2359-4685-aa1f-e10b9f693f01)