### PR TITLE
fix: serial API was taking percent but not mapping this to the PWM values.

### DIFF
--- a/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
@@ -189,15 +189,16 @@ void processJsonRpcMessage(const char* jsonString) {
       else
         result["rotation"] = "fail";
     }   
-    if(params["brightness"]){
+    if(params.containsKey("brightness")){
       uint16_t inx = params["brightness"].as<unsigned int>();
-      if(inx >= 50 && inx <= 1000) {
-        gloConfig->screen[0].brightness = inx;
-        gloConfig->screen[1].brightness = inx;
-        gloConfig->screen[2].brightness = inx;
+      if(inx <= 100) {
+        uint16_t pwm = ((uint32_t)inx * 1023 + 50) / 100;
+        gloConfig->screen[0].brightness = pwm;
+        gloConfig->screen[1].brightness = pwm;
+        gloConfig->screen[2].brightness = pwm;
       }
       else
-        result["brightness"] = "out of range (50-1000)";
+        result["brightness"] = "out of range (0-100% expected)";
     } 
     
     if(params["ledState"]){
@@ -291,8 +292,8 @@ void processJsonRpcMessage(const char* jsonString) {
         result["refreshRate"]   = t_refreshRate[gloConfig->features.refreshRate];
       if(pName == "rotation"      || all || conf)     
         result["rotation"]      = t_rotation[gloConfig->screen[0].rotation];
-      if(pName == "brightness"    || all || conf)   
-        result["brightness"]    = gloConfig->screen[0].brightness;
+      if(pName == "brightness"    || all || conf)
+        result["brightness"]    = ((uint32_t)gloConfig->screen[0].brightness * 100 + 511) / 1023;
       
       if(pName == "startUpActive" || all || state)
         result["startUpActive"] = gloState->features.startUpActive;

--- a/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
@@ -190,14 +190,14 @@ void processJsonRpcMessage(const char* jsonString) {
         result["rotation"] = "fail";
     }   
     if(params["brightness"]){
-      uint8_t inx = params["brightness"].as<unsigned int>();
-      if(inx >= 10 && inx <= 100) {
+      uint16_t inx = params["brightness"].as<unsigned int>();
+      if(inx >= 50 && inx <= 1000) {
         gloConfig->screen[0].brightness = inx;
         gloConfig->screen[1].brightness = inx;
         gloConfig->screen[2].brightness = inx;
       }
       else
-        result["brightness"] = "fail";
+        result["brightness"] = "out of range (50-1000)";
     } 
     
     if(params["ledState"]){

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/.gitignore
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.pytest_cache/
+__pycache__/
+report.html
+assets/
+logs/

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
@@ -1,0 +1,99 @@
+# USB Insight Hub — Serial Integration Tests
+
+Hardware integration tests for the Insight Hub's JSON serial API. These tests
+run against a real hub connected via USB and verify correct behavior of the
+serial command interface.
+
+## Prerequisites
+
+- USB Insight Hub connected via USB
+- Python 3.10+
+
+## Setup
+
+```bash
+cd USBInsightHub-A1/UIH-ESP32S3/test/integration
+python3 -m venv .venv
+source .venv/bin/activate   # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+The hub is auto-detected by USB VID/PID. Pass `--port` to override.
+
+```bash
+# Auto-detect hub, verbose output
+pytest -v
+
+# Explicit serial port
+pytest -v --port /dev/cu.usbmodemXXX
+
+# Run only channel query tests
+pytest -v -k channel
+```
+
+## Troubleshooting
+
+Every run writes a detailed log to `./logs/run-YYYYMMDD-HHMMSS.log` with full
+serial TX/RX traffic, timeouts, and JSON parse errors. The log path is printed
+at the end of the test summary.
+
+```bash
+# Run tests — log is written automatically
+pytest -v
+
+# Check the log
+cat logs/run-*.log | tail -40
+```
+
+To also show the serial traffic live on the console:
+
+```bash
+pytest -v --log-cli-level=DEBUG
+```
+
+## Test Report
+
+Generate an HTML report with `--html`:
+
+```bash
+pytest -v --html=report.html --self-contained-html
+```
+
+Generate a plain-text summary of what each test verifies:
+
+```bash
+pytest --co -q          # list test names
+pytest --co -v          # list test names with class/module structure
+```
+
+The tests are self-documenting — every test class and method has a docstring
+describing what it verifies. Use `pytest --co -v` to see the full hierarchy.
+
+## What's Tested
+
+| Area | Tests | Description |
+|------|-------|-------------|
+| **Channel queries** | 4 | Required fields (powerEn, dataEn, voltage, current) on CH1-CH3; extended query |
+| **Global config** | 3 | Meta-names (all/config/state); config param presence; startUpmode enum |
+| **Enum roundtrip** | 3 | filterType set/get with valid values; invalid enum rejection |
+| **Forward limit** | 4 | CH1 fwdLimit set/get across 100-2000 range |
+| **Power control** | 2 | CH1 power off/on via serial API |
+| **Edge cases** | 2 | Invalid action handling; firstStart auto-clear flag |
+
+**Total: 18 tests**
+
+## Safety
+
+All tests that modify state (power, fwdLimit, filterType) save the original
+value before testing and restore it in a fixture teardown, even if the test
+fails.
+
+## Test Structure
+
+```
+conftest.py          — Hub connection class, auto-detection, pytest fixtures
+test_serial_api.py   — Serial API test cases
+requirements.txt     — Python dependencies
+```

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/conftest.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/conftest.py
@@ -1,0 +1,163 @@
+import json
+import logging
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import serial
+from serial.tools.list_ports import comports
+
+log = logging.getLogger("hub")
+
+INSIGHT_HUB_VID = 0x303A
+INSIGHT_HUB_PID = 0x1001
+INSIGHT_HUB_PRODUCT = "InsightHUB Controller"
+
+LOGS_DIR = Path(__file__).parent / "logs"
+
+CONNECT_ATTEMPTS = 3
+CONNECT_SETTLE_S = 0.5
+
+
+def find_hub():
+    for p in comports():
+        if p.product == INSIGHT_HUB_PRODUCT or (
+            p.vid == INSIGHT_HUB_VID and p.pid == INSIGHT_HUB_PID
+        ):
+            return p.device
+    return None
+
+
+class HubConnectionError(Exception):
+    pass
+
+
+class Hub:
+    """Thin wrapper around the Insight Hub's JSON serial API."""
+
+    def __init__(self, port, timeout=2.0):
+        self.port = port
+        self.timeout = timeout
+        self.ser = None
+        self._connect()
+        self._verify_responsive()
+
+    def _connect(self):
+        log.info("Opening %s (timeout=%.1fs)", self.port, self.timeout)
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+        self.ser = serial.Serial(self.port, 115200, timeout=self.timeout)
+        self.ser.dtr = True
+        time.sleep(CONNECT_SETTLE_S)
+        self.ser.reset_input_buffer()
+        log.info("Opened %s", self.port)
+
+    def _dtr_reset(self):
+        """Toggle DTR to trigger a CDC reconnect on the ESP32-S3."""
+        log.info("DTR reset on %s", self.port)
+        self.ser.dtr = False
+        time.sleep(0.1)
+        self.ser.dtr = True
+        time.sleep(CONNECT_SETTLE_S)
+        self.ser.reset_input_buffer()
+
+    def _verify_responsive(self):
+        """Probe the hub with a simple get; retry with DTR reset if needed."""
+        for attempt in range(1, CONNECT_ATTEMPTS + 1):
+            log.info("Connection check attempt %d/%d", attempt, CONNECT_ATTEMPTS)
+            resp = self.send({"action": "get", "params": ["hubMode"]})
+            if resp and resp.get("status") == "ok":
+                log.info("Hub responsive on attempt %d", attempt)
+                return
+            if attempt < CONNECT_ATTEMPTS:
+                log.warning("Hub not responding, retrying with DTR reset...")
+                self._dtr_reset()
+
+        raise HubConnectionError(
+            f"Hub on {self.port} not responding after {CONNECT_ATTEMPTS} attempts. "
+            f"Try power-cycling the hub (unplug/replug USB)."
+        )
+
+    def send(self, msg):
+        payload = json.dumps(msg, separators=(",", ":")) + "\n"
+        log.debug("TX: %s", payload.rstrip())
+        self.ser.write(payload.encode())
+        self.ser.flush()
+        line = self.ser.readline().decode("utf-8", errors="replace").strip()
+        if line:
+            log.debug("RX: %s", line)
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("RX not valid JSON: %r", line)
+                return None
+        log.debug("RX: (timeout, no response)")
+        return None
+
+    def get(self, *params):
+        resp = self.send({"action": "get", "params": list(params)})
+        if resp and resp.get("status") == "ok":
+            return resp.get("data", {})
+        log.warning("get(%s) failed: %r", params, resp)
+        return None
+
+    def set(self, params):
+        resp = self.send({"action": "set", "params": params})
+        ok = resp and resp.get("status") == "ok"
+        if not ok:
+            log.warning("set(%s) failed: %r", params, resp)
+        return ok
+
+    def close(self):
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--port", default=None, help="Serial port for Insight Hub (auto-detect if omitted)"
+    )
+
+
+def pytest_configure(config):
+    """Set up file logging for every test run."""
+    LOGS_DIR.mkdir(exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    logfile = LOGS_DIR / f"run-{timestamp}.log"
+
+    handler = logging.FileHandler(logfile)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)-7s %(name)s  %(message)s",
+        datefmt="%H:%M:%S",
+    ))
+    logging.getLogger("hub").addHandler(handler)
+    logging.getLogger("hub").setLevel(logging.DEBUG)
+
+    # Store path so we can print it in the summary
+    config._hub_logfile = logfile
+
+
+def pytest_terminal_summary(terminalreporter, config):
+    logfile = getattr(config, "_hub_logfile", None)
+    if logfile:
+        terminalreporter.write_sep("-", f"serial log: {logfile}")
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """Connect to the hub before any tests run. Abort early on failure."""
+    port = config.getoption("--port") or find_hub()
+    if not port:
+        pytest.exit("No Insight Hub found. Pass --port or connect a hub.", returncode=1)
+    try:
+        config._hub_instance = Hub(port)
+    except (HubConnectionError, serial.SerialException) as e:
+        pytest.exit(f"ERROR: {e}", returncode=1)
+
+
+@pytest.fixture(scope="session")
+def hub(request):
+    h = request.config._hub_instance
+    yield h
+    h.close()

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/requirements.txt
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/requirements.txt
@@ -1,0 +1,3 @@
+pyserial>=3.5
+pytest>=7.0
+pytest-html>=4.0

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_brightness.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_brightness.py
@@ -1,0 +1,78 @@
+"""Integration tests for the brightness uint16_t fix.
+
+Verifies that brightness values in the 50-1000 range roundtrip correctly
+(previously truncated via uint8_t) and that out-of-range values are rejected.
+"""
+
+import time
+
+import pytest
+
+
+class TestBrightnessRoundtrip:
+    """Verify the uint16_t brightness fix: set/get across 50-1000."""
+
+    @pytest.fixture(autouse=True)
+    def _save_restore_brightness(self, hub):
+        data = hub.get("brightness")
+        self._orig = data.get("brightness") if data else None
+        yield
+        if self._orig is not None:
+            hub.set({"brightness": self._orig})
+
+    @pytest.mark.parametrize("val", [50, 100, 200, 500, 800, 1000])
+    def test_roundtrip(self, hub, val):
+        """Set brightness to val, read it back, verify it matches."""
+        hub.set({"brightness": val})
+        time.sleep(0.1)
+        data = hub.get("brightness")
+        assert data is not None, "get brightness returned None"
+        assert data["brightness"] == val
+
+    def test_default_800_roundtrips(self, hub):
+        """800 is the factory default — previously truncated to 32 via uint8_t."""
+        hub.set({"brightness": 800})
+        time.sleep(0.1)
+        data = hub.get("brightness")
+        assert data["brightness"] == 800
+
+
+class TestBrightnessOutOfRange:
+    """Brightness rejects values outside 50-1000."""
+
+    @pytest.fixture(autouse=True)
+    def _save_restore_brightness(self, hub):
+        data = hub.get("brightness")
+        self._orig = data.get("brightness") if data else None
+        yield
+        if self._orig is not None:
+            hub.set({"brightness": self._orig})
+
+    @pytest.mark.parametrize("val", [10, 49, 1001, 2000])
+    def test_rejects_invalid(self, hub, val):
+        """Setting brightness outside 50-1000 returns an 'out of range' error."""
+        resp = hub.send({"action": "set", "params": {"brightness": val}})
+        data = resp.get("data", {}) if resp else {}
+        assert "brightness" in data
+        assert "out of range" in str(data["brightness"])
+
+    def test_zero_is_ignored(self, hub):
+        """ArduinoJson treats 0 as falsy, so brightness=0 is silently skipped."""
+        before = hub.get("brightness")
+        before_val = before.get("brightness") if before else None
+        hub.send({"action": "set", "params": {"brightness": 0}})
+        time.sleep(0.1)
+        after = hub.get("brightness")
+        assert after.get("brightness") == before_val
+
+    def test_value_unchanged_after_invalid(self, hub):
+        """Invalid brightness values do not alter the stored brightness."""
+        before = hub.get("brightness")
+        before_val = before.get("brightness") if before else None
+
+        hub.send({"action": "set", "params": {"brightness": 9999}})
+        time.sleep(0.1)
+
+        after = hub.get("brightness")
+        after_val = after.get("brightness") if after else None
+        assert after_val == before_val

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_brightness.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_brightness.py
@@ -1,7 +1,8 @@
-"""Integration tests for the brightness uint16_t fix.
+"""Integration tests for brightness percentage API.
 
-Verifies that brightness values in the 50-1000 range roundtrip correctly
-(previously truncated via uint8_t) and that out-of-range values are rejected.
+The serial API accepts brightness as a percentage (0-100) and converts to
+a 10-bit PWM value (0-1023) internally.  The get handler converts back to
+percentage for the response.
 """
 
 import time
@@ -10,7 +11,7 @@ import pytest
 
 
 class TestBrightnessRoundtrip:
-    """Verify the uint16_t brightness fix: set/get across 50-1000."""
+    """Verify brightness percentage set/get roundtrip."""
 
     @pytest.fixture(autouse=True)
     def _save_restore_brightness(self, hub):
@@ -20,25 +21,25 @@ class TestBrightnessRoundtrip:
         if self._orig is not None:
             hub.set({"brightness": self._orig})
 
-    @pytest.mark.parametrize("val", [50, 100, 200, 500, 800, 1000])
-    def test_roundtrip(self, hub, val):
-        """Set brightness to val, read it back, verify it matches."""
-        hub.set({"brightness": val})
+    @pytest.mark.parametrize("pct", [1, 10, 25, 50, 75, 100])
+    def test_roundtrip(self, hub, pct):
+        """Set brightness to pct%, read it back, verify it matches."""
+        hub.set({"brightness": pct})
         time.sleep(0.1)
         data = hub.get("brightness")
         assert data is not None, "get brightness returned None"
-        assert data["brightness"] == val
+        assert data["brightness"] == pct
 
-    def test_default_800_roundtrips(self, hub):
-        """800 is the factory default — previously truncated to 32 via uint8_t."""
-        hub.set({"brightness": 800})
+    def test_zero_turns_off(self, hub):
+        """brightness=0 sets PWM to 0 (display off)."""
+        hub.set({"brightness": 0})
         time.sleep(0.1)
         data = hub.get("brightness")
-        assert data["brightness"] == 800
+        assert data["brightness"] == 0
 
 
 class TestBrightnessOutOfRange:
-    """Brightness rejects values outside 50-1000."""
+    """Brightness rejects values outside 0-100."""
 
     @pytest.fixture(autouse=True)
     def _save_restore_brightness(self, hub):
@@ -48,31 +49,21 @@ class TestBrightnessOutOfRange:
         if self._orig is not None:
             hub.set({"brightness": self._orig})
 
-    @pytest.mark.parametrize("val", [10, 49, 1001, 2000])
+    @pytest.mark.parametrize("val", [101, 200, 1000])
     def test_rejects_invalid(self, hub, val):
-        """Setting brightness outside 50-1000 returns an 'out of range' error."""
+        """Setting brightness outside 0-100 returns a 'fail' error."""
         resp = hub.send({"action": "set", "params": {"brightness": val}})
         data = resp.get("data", {}) if resp else {}
-        assert "brightness" in data
-        assert "out of range" in str(data["brightness"])
-
-    def test_zero_is_ignored(self, hub):
-        """ArduinoJson treats 0 as falsy, so brightness=0 is silently skipped."""
-        before = hub.get("brightness")
-        before_val = before.get("brightness") if before else None
-        hub.send({"action": "set", "params": {"brightness": 0}})
-        time.sleep(0.1)
-        after = hub.get("brightness")
-        assert after.get("brightness") == before_val
+        assert "out of range" in str(data.get("brightness"))
 
     def test_value_unchanged_after_invalid(self, hub):
         """Invalid brightness values do not alter the stored brightness."""
+        hub.set({"brightness": 50})
+        time.sleep(0.1)
         before = hub.get("brightness")
-        before_val = before.get("brightness") if before else None
 
-        hub.send({"action": "set", "params": {"brightness": 9999}})
+        hub.send({"action": "set", "params": {"brightness": 999}})
         time.sleep(0.1)
 
         after = hub.get("brightness")
-        after_val = after.get("brightness") if after else None
-        assert after_val == before_val
+        assert after["brightness"] == before["brightness"]

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_serial_api.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_serial_api.py
@@ -1,0 +1,161 @@
+"""Integration tests for USB Insight Hub serial API.
+
+Tests cover the existing serial API functionality: channel queries,
+global config, enum roundtrip, forward current limits, power control,
+and edge cases.
+
+Requires a real hub connected via USB.
+
+Usage:
+    pytest test/integration/ -v                              # auto-detect hub
+    pytest test/integration/ -v --port /dev/cu.usbmodemXXX   # explicit port
+"""
+
+import time
+
+import pytest
+
+
+# ── Channel queries ──────────────────────────────────────────
+
+
+class TestChannelQuery:
+    """Query each channel returns expected fields."""
+
+    @pytest.mark.parametrize("ch", ["CH1", "CH2", "CH3"])
+    def test_channel_has_required_fields(self, hub, ch):
+        """Each channel reports powerEn, dataEn, voltage, and current."""
+        data = hub.get(ch)
+        assert data is not None and ch in data
+        state = data[ch]
+        for field in ("powerEn", "dataEn", "voltage", "current"):
+            assert field in state, f"{ch} missing {field}"
+
+    def test_extended_query(self, hub):
+        """CH1_all returns extra fields beyond CH1."""
+        data = hub.get("CH1_all")
+        assert data is not None and "CH1" in data
+        state = data["CH1"]
+        for field in ("ilim", "fwdLimit", "backLimit", "startup_tmr"):
+            assert field in state, f"CH1_all missing {field}"
+
+
+# ── Global config ────────────────────────────────────────────
+
+
+class TestGlobalConfig:
+    def test_meta_names(self, hub):
+        """Meta-names 'all', 'config', 'state' return data."""
+        for meta in ["all", "config", "state"]:
+            data = hub.get(meta)
+            assert data is not None and len(data) > 0, f"get '{meta}' empty"
+
+    def test_config_params(self, hub):
+        """Config response includes startUpmode, wifi_enabled, hubMode, brightness."""
+        data = hub.get("config")
+        assert data is not None
+        for key in ("startUpmode", "wifi_enabled", "hubMode", "brightness"):
+            assert key in data, f"config missing {key}"
+
+    def test_startup_mode_valid(self, hub):
+        """startUpmode is one of the known enum values."""
+        data = hub.get("config")
+        valid = ("persistance", "on_at_start", "off_at_start", "sequence")
+        assert data["startUpmode"] in valid, f"got {data['startUpmode']}"
+
+
+# ── Set/get roundtrips ───────────────────────────────────────
+
+
+class TestEnumRoundtrip:
+    """Enum parameters accept valid values and reject invalid ones."""
+
+    @pytest.fixture(autouse=True)
+    def _save_restore_filter(self, hub):
+        data = hub.get("filterType")
+        self._orig = data.get("filterType") if data else None
+        yield
+        if self._orig is not None:
+            hub.set({"filterType": self._orig})
+
+    @pytest.mark.parametrize("val", ["moving_avg", "median"])
+    def test_filter_type(self, hub, val):
+        """filterType set/get roundtrip with valid enum values."""
+        hub.set({"filterType": val})
+        time.sleep(0.1)
+        data = hub.get("filterType")
+        assert data.get("filterType") == val
+
+    def test_rejects_invalid(self, hub):
+        """Invalid enum value returns 'fail'."""
+        resp = hub.send({"action": "set", "params": {"filterType": "bogus"}})
+        data = resp.get("data", {}) if resp else {}
+        assert data.get("filterType") == "fail"
+
+
+class TestFwdLimitRoundtrip:
+    """Per-channel forward current limit set/get roundtrip."""
+
+    @pytest.fixture(autouse=True)
+    def _save_restore_fwd_limit(self, hub):
+        data = hub.get("CH1_all")
+        self._orig = data["CH1"].get("fwdLimit") if data and "CH1" in data else None
+        yield
+        if self._orig is not None:
+            hub.set({"CH1": {"fwdLimit": self._orig}})
+
+    @pytest.mark.parametrize("val", [100, 500, 1000, 2000])
+    def test_roundtrip(self, hub, val):
+        """Set CH1 fwdLimit, read back via CH1_all, verify match."""
+        hub.set({"CH1": {"fwdLimit": val}})
+        time.sleep(0.1)
+        data = hub.get("CH1_all")
+        assert data["CH1"].get("fwdLimit") == val
+
+
+# ── Power control ────────────────────────────────────────────
+
+
+class TestPowerToggle:
+    """Power on/off control via serial API on CH1."""
+
+    @pytest.fixture(autouse=True)
+    def _save_restore_power(self, hub):
+        data = hub.get("CH1")
+        self._orig = data["CH1"].get("powerEn") if data and "CH1" in data else True
+        yield
+        hub.set({"CH1": {"powerEn": "true" if self._orig else "false"}})
+
+    def test_power_off(self, hub):
+        """Turning CH1 off sets powerEn to False."""
+        hub.set({"CH1": {"powerEn": "false"}})
+        time.sleep(0.3)
+        data = hub.get("CH1")
+        assert data["CH1"]["powerEn"] is False
+
+    def test_power_on(self, hub):
+        """Turning CH1 on after off sets powerEn to True."""
+        hub.set({"CH1": {"powerEn": "false"}})
+        time.sleep(0.3)
+        hub.set({"CH1": {"powerEn": "true"}})
+        time.sleep(0.3)
+        data = hub.get("CH1")
+        assert data["CH1"]["powerEn"] is True
+
+
+# ── Edge cases ───────────────────────────────────────────────
+
+
+def test_invalid_action(hub):
+    """Invalid action returns without hanging."""
+    resp = hub.send({"action": "bogus", "params": {}})
+    # if we get here it didn't hang — that's the main assertion
+    assert resp is None or isinstance(resp, dict)
+
+
+def test_first_start_flag(hub):
+    """firstStart auto-clears after first read."""
+    hub.get("firstStart")  # consume
+    data = hub.get("firstStart")
+    assert data is not None
+    assert data.get("firstStart") is False


### PR DESCRIPTION
  ## Summary

  - Brightness values >255 were silently truncated because `Extercomms.cpp` stored the value in a `uint8_t`. Changed to `uint16_t`.
  - Updated valid range from 10–100 to 50–1000 to match the web UI.
  - Added 31 pytest integration tests covering brightness roundtrip, out-of-range rejection, channel queries, enum roundtrip, forward limit, power toggle, and edge cases.

  ## Test plan

  - [ ] Install the python venv and dependencies to run the integration tests - see [integration test README](USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md) for setup and usage.
  - [ ] Connect hub via USB, run `pytest -v -k brightness` from `test/integration/` (omit `-k brightness` to run all tests.) 
  - [ ] Verify Tests Pass:
    - [ ] Verify brightness set/get roundtrip at values 250, 500, 800, 1000
    - [ ] Verify out-of-range values (10, 49, 1001) are rejected
    - [ ] Final output looks like: 
       <details><summary>expected output</summary>test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[50] PASSED   [  7%]
test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[100] PASSED  [ 15%]
test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[200] PASSED  [ 23%]
test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[500] PASSED  [ 30%]
test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[800] PASSED  [ 38%]
test_brightness.py::TestBrightnessRoundtrip::test_roundtrip[1000] PASSED [ 46%]
test_brightness.py::TestBrightnessRoundtrip::test_default_800_roundtrips PASSED [ 53%]
test_brightness.py::TestBrightnessOutOfRange::test_rejects_invalid[10] PASSED [ 61%]
test_brightness.py::TestBrightnessOutOfRange::test_rejects_invalid[49] PASSED [ 69%]
test_brightness.py::TestBrightnessOutOfRange::test_rejects_invalid[1001] PASSED [ 76%]
test_brightness.py::TestBrightnessOutOfRange::test_rejects_invalid[2000] PASSED [ 84%]
test_brightness.py::TestBrightnessOutOfRange::test_zero_is_ignored PASSED [ 92%]
test_brightness.py::TestBrightnessOutOfRange::test_value_unchanged_after_invalid PASSED [100%]

- serial log: /Users/mat/e/USB-Insight-HUB-Software/USBInsightHub-A1/UIH-ESP32S3/test/integration/logs/run-20260224-110741.log -
====================== 13 passed, 18 deselected in 3.96s =======================           
       </details>

