### PR TITLE
feat: add OTA firmware upload scripts (.bat/.sh)

### DIFF
--- a/USBInsightHub-A1/UIH-ESP32S3/scripts/ota_upload.bat
+++ b/USBInsightHub-A1/UIH-ESP32S3/scripts/ota_upload.bat
@@ -1,0 +1,47 @@
+@echo off
+REM Upload firmware to USB Insight Hub via OTA (HTTP)
+REM Usage: ota_upload.bat [host] [firmware.bin]
+REM Environment variables UIH_HOST and UIH_FIRMWARE override the defaults.
+REM Requires: curl (included in Windows 10+)
+
+setlocal enabledelayedexpansion
+
+set "HOST=%~1"
+if "%HOST%"=="" if defined UIH_HOST (set "HOST=%UIH_HOST%") else (set "HOST=insighthub.local")
+
+set "FIRMWARE=%~2"
+if "%FIRMWARE%"=="" if defined UIH_FIRMWARE (set "FIRMWARE=%UIH_FIRMWARE%") else (set "FIRMWARE=%~dp0..\.pio\build\esp32-s3-uih\firmware.bin")
+
+if not exist "%FIRMWARE%" (
+    echo error: firmware not found: %FIRMWARE% >&2
+    echo usage: %~nx0 [host] [firmware.bin] >&2
+    exit /b 1
+)
+
+for %%F in ("%FIRMWARE%") do set "FNAME=%%~nxF" & set "FSIZE=%%~zF"
+echo Uploading %FNAME% (%FSIZE% bytes) to %HOST%...
+
+curl -s -w "%%{http_code}" -o NUL ^
+    --connect-timeout 5 ^
+    --max-time 120 ^
+    -X POST ^
+    -F "file=@%FIRMWARE%;filename=%FNAME%" ^
+    "http://%HOST%/rest/uploadFirmware" > "%TEMP%\ota_http_code.tmp"
+
+set /p HTTP_CODE=<"%TEMP%\ota_http_code.tmp"
+del "%TEMP%\ota_http_code.tmp" 2>nul
+
+if "%HTTP_CODE%"=="200" (
+    echo Upload successful — hub is rebooting.
+    echo Wait ~10s for it to come back online.
+    exit /b 0
+)
+
+echo error: upload failed (HTTP %HTTP_CODE%) >&2
+if "%HTTP_CODE%"=="403" echo   → Forbidden (admin auth required) >&2
+if "%HTTP_CODE%"=="406" echo   → Not acceptable (wrong file type, must be .bin) >&2
+if "%HTTP_CODE%"=="500" echo   → Internal error (flash write failed) >&2
+if "%HTTP_CODE%"=="503" echo   → Wrong chip type (not ESP32-S3 firmware) >&2
+if "%HTTP_CODE%"=="507" echo   → Insufficient storage (firmware too large) >&2
+if "%HTTP_CODE%"=="000" echo   → Connection failed (is the hub on the network?) >&2
+exit /b 1

--- a/USBInsightHub-A1/UIH-ESP32S3/scripts/ota_upload.sh
+++ b/USBInsightHub-A1/UIH-ESP32S3/scripts/ota_upload.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Upload firmware to USB Insight Hub via OTA (HTTP)
+# Usage: ota_upload.sh [host] [firmware.bin]
+# Environment variables UIH_HOST and UIH_FIRMWARE override the defaults.
+set -euo pipefail
+
+HOST="${1:-${UIH_HOST:-insighthub.local}}"
+FIRMWARE="${2:-${UIH_FIRMWARE:-$(dirname "$0")/../.pio/build/esp32-s3-uih/firmware.bin}}"
+
+if [ ! -f "$FIRMWARE" ]; then
+    echo "error: firmware not found: $FIRMWARE" >&2
+    echo "usage: $0 [host] [firmware.bin]" >&2
+    exit 1
+fi
+
+SIZE=$(stat -f%z "$FIRMWARE" 2>/dev/null || stat -c%s "$FIRMWARE" 2>/dev/null)
+echo "Uploading $(basename "$FIRMWARE") (${SIZE} bytes) to ${HOST}..."
+
+# Upload with progress
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+    --connect-timeout 5 \
+    --max-time 120 \
+    -X POST \
+    -F "file=@${FIRMWARE};filename=$(basename "$FIRMWARE")" \
+    "http://${HOST}/rest/uploadFirmware")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "Upload successful — hub is rebooting."
+    echo "Wait ~10s for it to come back online."
+else
+    echo "error: upload failed (HTTP ${HTTP_CODE})" >&2
+    case "$HTTP_CODE" in
+        403) echo "  → Forbidden (admin auth required)" >&2 ;;
+        406) echo "  → Not acceptable (wrong file type, must be .bin)" >&2 ;;
+        500) echo "  → Internal error (flash write failed)" >&2 ;;
+        503) echo "  → Wrong chip type (not ESP32-S3 firmware)" >&2 ;;
+        507) echo "  → Insufficient storage (firmware too large)" >&2 ;;
+        000) echo "  → Connection failed (is the hub on the network?)" >&2 ;;
+    esac
+    exit 1
+fi


### PR DESCRIPTION
## Summary                                                                                                                                  
                                                                                                                                              
  - Add `ota_upload.sh` (macOS/Linux) and `ota_upload.bat` (Windows) for uploading firmware via HTTP POST to `/rest/uploadFirmware`
  - Defaults overridable via `UIH_HOST` and `UIH_FIRMWARE` environment variables or positional arguments. The defaults are:
    - Host: `insighthub.local`                                                                                                                 
    - Firmware: `../.pio/build/esp32-s3-uih/firmware.bin`                              
  - Detailed error messages for common HTTP failure codes (403, 406, 500, 503, 507)

  ## Usage

  ```bash
  # Use defaults (insighthub.local, PIO build output)
  ./scripts/ota_upload.sh

  # Override via env vars
  UIH_HOST=192.168.1.50 ./scripts/ota_upload.sh

  # Override via positional args
  ./scripts/ota_upload.sh myhub.local path/to/firmware.bin
```
