### PR TITLE
feat: NVS persistence tests and brightness migration fix

### DIFF
--- a/USBInsightHub-A1/UIH-ESP32S3/scripts/nvs_dump.sh
+++ b/USBInsightHub-A1/UIH-ESP32S3/scripts/nvs_dump.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Dump the NVS partition from an Insight Hub to a binary file.
+#
+# The hub must be in ROM bootloader mode before running this script.
+# Enter bootloader by enabling reboot_enabled=1 via the serial API or
+# web UI, then performing a 1200-baud touch on the serial port.
+#
+# Usage:
+#   ./scripts/nvs_dump.sh /dev/cu.usbmodemXXX
+#   ./scripts/nvs_dump.sh /dev/cu.usbmodemXXX my-snapshot.bin
+#
+# After dumping, the hub stays in bootloader mode (--after no_reset).
+# Use nvs_restore.sh or esptool hard_reset to return to the app.
+set -euo pipefail
+
+NVS_OFFSET=0x9000
+NVS_SIZE=0x5000
+
+PORT="${1:-}"
+OUTPUT="${2:-nvs_snapshot.bin}"
+
+if [ -z "$PORT" ]; then
+    echo "usage: $0 <bootloader-port> [output.bin]" >&2
+    echo "  Port is required — auto-detect is intentionally disabled to avoid" >&2
+    echo "  flashing the wrong device. List ports with: python3 -m serial.tools.list_ports -v" >&2
+    exit 1
+fi
+
+echo "Reading NVS partition (${NVS_OFFSET}, ${NVS_SIZE} bytes) from ${PORT}..."
+
+esptool.py --port "$PORT" --chip esp32s3 --no-stub \
+    --after no_reset \
+    read_flash "$NVS_OFFSET" "$NVS_SIZE" "$OUTPUT"
+
+SIZE=$(stat -f%z "$OUTPUT" 2>/dev/null || stat -c%s "$OUTPUT" 2>/dev/null)
+echo "NVS dump saved to ${OUTPUT} (${SIZE} bytes)"
+echo ""
+echo "Hub is still in bootloader mode. To return to the app:"
+echo "  ./scripts/nvs_restore.sh ${PORT} ${OUTPUT}   # restore and reboot"
+echo "  # or just reboot:"
+echo "  esptool.py --port ${PORT} --chip esp32s3 --no-stub --after hard_reset write_mem 0x6000812C 0x0 0x1"

--- a/USBInsightHub-A1/UIH-ESP32S3/scripts/nvs_restore.sh
+++ b/USBInsightHub-A1/UIH-ESP32S3/scripts/nvs_restore.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Restore the NVS partition on an Insight Hub from a binary file.
+#
+# The hub must be in ROM bootloader mode before running this script.
+# Enter bootloader by enabling reboot_enabled=1 via the serial API or
+# web UI, then performing a 1200-baud touch on the serial port.
+#
+# After writing, the hub is hard-reset back into the application with
+# the restored NVS data.
+#
+# Usage:
+#   ./scripts/nvs_restore.sh /dev/cu.usbmodemXXX nvs_snapshot.bin
+set -euo pipefail
+
+NVS_OFFSET=0x9000
+
+PORT="${1:-}"
+INPUT="${2:-}"
+
+if [ -z "$PORT" ] || [ -z "$INPUT" ]; then
+    echo "usage: $0 <bootloader-port> <nvs_snapshot.bin>" >&2
+    echo "  Port is required — auto-detect is intentionally disabled to avoid" >&2
+    echo "  flashing the wrong device. List ports with: python3 -m serial.tools.list_ports -v" >&2
+    exit 1
+fi
+
+if [ ! -f "$INPUT" ]; then
+    echo "error: file not found: $INPUT" >&2
+    exit 1
+fi
+
+SIZE=$(stat -f%z "$INPUT" 2>/dev/null || stat -c%s "$INPUT" 2>/dev/null)
+echo "Writing NVS partition (${NVS_OFFSET}, ${SIZE} bytes) to ${PORT} from ${INPUT}..."
+
+esptool.py --port "$PORT" --chip esp32s3 --no-stub \
+    --after hard_reset \
+    write_flash "$NVS_OFFSET" "$INPUT"
+
+echo "NVS restored. Hub is rebooting into the application."

--- a/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
@@ -14,6 +14,7 @@
 //Handlers for the communication with external devices through USB Serial
 
 #include "Extercomms.h"
+#include <RestartService.h>
 
 //USB Serial and Harware Serial (Debug)
 #if ARDUINO_USB_CDC_ON_BOOT
@@ -68,6 +69,7 @@ void iniExtercomms(GlobalState* globalState, GlobalConfig* globalConfig){
     usbSerial.onEvent(usbEventCallback);
 
     usbSerial.begin(115200);
+    usbSerial.enableReboot(globalConfig->features.reboot_enabled == ENABLE);
     USB.manufacturerName("Aerio");
     USB.productName("InsightHUB Controller");
     USB.begin();
@@ -269,8 +271,18 @@ void processJsonRpcMessage(const char* jsonString) {
       }
       else
         result["brightness"] = "out of range (5-100% expected)";
-    } 
-    
+    }
+
+    if(params.containsKey("reboot_enabled")){
+      uint8_t val = params["reboot_enabled"].as<unsigned int>();
+      if(val <= 1) {
+        gloConfig->features.reboot_enabled = val;
+        usbSerial.enableReboot(val == ENABLE);
+      } else {
+        result["reboot_enabled"] = "fail";
+      }
+    }
+
     if(params["ledState"]){
       int inx = getEnumIndex(params["ledState"].as<const char*>(),t_bool,ARR_SIZE(t_bool));
       inx != -1 ? gloState->system.ledState = inx : result["ledState"] = "fail";        
@@ -369,7 +381,9 @@ void processJsonRpcMessage(const char* jsonString) {
         result["rotation"]      = t_rotation[gloConfig->screen[0].rotation];
       if(pName == "brightness"    || all || conf)
         result["brightness"]    = ((uint32_t)gloConfig->screen[0].brightness * 100 + 511) / 1023;
-      
+      if(pName == "reboot_enabled" || all || conf)
+        result["reboot_enabled"] = gloConfig->features.reboot_enabled;
+
       if(pName == "startUpActive" || all || state)
         result["startUpActive"] = gloState->features.startUpActive;
       if(pName == "pcConnected"   || all || state)  
@@ -416,6 +430,8 @@ void processJsonRpcMessage(const char* jsonString) {
       }  
       if(pName == "pacRev"    || all || state)
         result["pacRev"]      = String(gloState->system.pacRevisionID);
+      if(pName == "uptime"    || all || state)
+        result["uptime"]      = millis();
 
       for(int i = 0; i<3; i++){
         if (pName == "CH"+String(i+1) || pName == "CH"+String(i+1)+"_all"){
@@ -445,7 +461,19 @@ void processJsonRpcMessage(const char* jsonString) {
 
     sendJsonResponse(0, result);
   }
-  
+  else if(action == "restart"){
+    JsonObject params = doc["params"].as<JsonObject>();
+    bool immediate = params["immediate"] | false;
+    sendJsonResponse(0, result);
+    usbSerial.flush();
+    if(immediate){
+      delay(100);
+      ESP.restart();
+    } else {
+      RestartService::restartNow();
+    }
+  }
+
 }
 
 // Send JSON-RPC response

--- a/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/Extercomms.cpp
@@ -264,7 +264,7 @@ void processJsonRpcMessage(const char* jsonString) {
       //5% is minimum brighness. A complete dark display(0%) may lead to confusion and make
       //difficult to restore using the UIH menu 
       if(inx >= 5 && inx <= 100) {
-        uint16_t pwm = ((uint32_t)inx * 1023 + 50) / 100;
+        uint16_t pwm = brightnessPctToPwm(inx);
         gloConfig->screen[0].brightness = pwm;
         gloConfig->screen[1].brightness = pwm;
         gloConfig->screen[2].brightness = pwm;
@@ -380,7 +380,7 @@ void processJsonRpcMessage(const char* jsonString) {
       if(pName == "rotation"      || all || conf)     
         result["rotation"]      = t_rotation[gloConfig->screen[0].rotation];
       if(pName == "brightness"    || all || conf)
-        result["brightness"]    = ((uint32_t)gloConfig->screen[0].brightness * 100 + 511) / 1023;
+        result["brightness"]    = brightnessPwmToPct(gloConfig->screen[0].brightness);
       if(pName == "reboot_enabled" || all || conf)
         result["reboot_enabled"] = gloConfig->features.reboot_enabled;
 

--- a/USBInsightHub-A1/UIH-ESP32S3/src/GlobalStateManager.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/GlobalStateManager.cpp
@@ -309,7 +309,15 @@ void migrateLegacyTemplate(GlobalConfig *globalConfig){
         for(int i = 0; i < 3; i++) {
             globalConfig->startup[i].startup_timer = lglobalConfig.startup[i].startup_timer;
             globalConfig->screen[i].rotation = lglobalConfig.screen[i].rotation;
-            globalConfig->screen[i].brightness = lglobalConfig.screen[i].brightness;
+            // v1.0.0 stored brightness inconsistently: serial API wrote 10-100
+            // (percentage), but the on-board menu wrote 50-1000 (raw PWM) and the
+            // default was 800 (PWM).  Detect which format we have by range.
+            uint16_t legacyBrightness = lglobalConfig.screen[i].brightness;
+            if (legacyBrightness <= 100) {
+                globalConfig->screen[i].brightness = brightnessPctToPwm(legacyBrightness);
+            } else {
+                globalConfig->screen[i].brightness = legacyBrightness;
+            }
             globalConfig->meter[i].backCLim = lglobalConfig.meter[i].backCLim;
             globalConfig->meter[i].fwdCLim = lglobalConfig.meter[i].fwdCLim;
         }

--- a/USBInsightHub-A1/UIH-ESP32S3/src/GlobalStateManager.cpp
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/GlobalStateManager.cpp
@@ -196,7 +196,8 @@ void setDefaultGlobalConfig(GlobalState *globalState, GlobalConfig *globalConfig
     globalConfig->features.wifi_enabled = ENABLE;
     globalConfig->features.hubMode = USB2_3;
     globalConfig->features.filterType = FILTER_TYPE_MEDIAN;
-    globalConfig->features.refreshRate = S0_5;        
+    globalConfig->features.refreshRate = S0_5;
+    globalConfig->features.reboot_enabled = DISABLE;
 
     for(int i=0; i<3; i++){
         globalConfig->startup[i].startup_timer = 1;
@@ -229,7 +230,8 @@ void writeGlobalConfigasKeyValuePairs(GlobalConfig *globalConfig)
     flashstorage.putUChar("f_hubMode", globalConfig->features.hubMode);
     flashstorage.putUChar("f_filterType", globalConfig->features.filterType);
     flashstorage.putUChar("f_refreshRate", globalConfig->features.refreshRate);
-    
+    flashstorage.putUChar("f_reboot_en", globalConfig->features.reboot_enabled);
+
     char key[16];  // <= 15 + null
 
     for(int i = 0; i < 3; i++) {
@@ -265,7 +267,8 @@ void readGlobalConfigasKeyValuePairs(GlobalConfig *globalConfig)
     globalConfig->features.hubMode = flashstorage.getUChar("f_hubMode", globalConfig->features.hubMode);
     globalConfig->features.filterType = flashstorage.getUChar("f_filterType", globalConfig->features.filterType);
     globalConfig->features.refreshRate = flashstorage.getUChar("f_refreshRate", globalConfig->features.refreshRate);
-    
+    globalConfig->features.reboot_enabled = flashstorage.getUChar("f_reboot_en", globalConfig->features.reboot_enabled);
+
     char key[16];  // <= 15 + null
 
     for(int i = 0; i < 3; i++) {

--- a/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
@@ -224,8 +224,12 @@ struct StartupConfig {
 
 struct ScreenConfig {
   uint8_t rotation;
-  uint16_t brightness;
+  uint16_t brightness;  // 10-bit PWM (0-1023)
 };
+
+// Brightness helpers — convert between user-facing percentage and internal PWM
+inline uint16_t brightnessPctToPwm(uint16_t pct) { return (uint16_t)((uint32_t)pct * 1023 + 50) / 100; }
+inline uint16_t brightnessPwmToPct(uint16_t pwm) { return (uint16_t)((uint32_t)pwm * 100 + 511) / 1023; }
 
 struct MeterState {
   float AvgVoltage;

--- a/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
+++ b/USBInsightHub-A1/UIH-ESP32S3/src/datatypes.h
@@ -209,8 +209,9 @@ struct FeaturesConfig {
   uint8_t startUpmode;  
   uint8_t wifi_enabled;
   uint8_t hubMode;
-  uint8_t filterType;    
+  uint8_t filterType;
   uint8_t refreshRate;
+  uint8_t reboot_enabled;
 };
 
 struct StartupState { 

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
@@ -24,14 +24,39 @@ The hub is auto-detected by USB VID/PID. Pass `--port` to override.
 
 ```bash
 # Auto-detect hub, verbose output
-pytest -v
+.venv/bin/pytest -v
 
 # Explicit serial port
-pytest -v --port /dev/cu.usbmodemXXX
+.venv/bin/pytest -v --port /dev/cu.usbmodemXXX
+
+# Skip slow tests (reboot, bootloader operations)
+.venv/bin/pytest -v --quick
 
 # Run only channel query tests
-pytest -v -k channel
+.venv/bin/pytest -v -k channel
 ```
+
+### NVS Persistence Tests
+
+Tests that settings survive a reboot. Requires the current firmware with
+`restart` support.
+
+```bash
+.venv/bin/pytest test_nvs_persistence.py -v -s
+```
+
+### NVS Upgrade Migration Test
+
+Tests the v1.0.0 → current firmware migration path via OTA. Requires WiFi
+connectivity to the hub.
+
+```bash
+.venv/bin/pytest test_nvs_upgrade.py -v -s --host insighthub.local
+```
+
+The `--old-firmware` and `--new-firmware` options default to
+`build/firmware/USBInsightHub-A0_esp32-s3-uih_1-0-0.bin` and
+`.pio/build/esp32-s3-uih/firmware.bin` respectively.
 
 ## Troubleshooting
 
@@ -81,8 +106,10 @@ describing what it verifies. Use `pytest --co -v` to see the full hierarchy.
 | **Forward limit** | 4 | CH1 fwdLimit set/get across 100-2000 range |
 | **Power control** | 2 | CH1 power off/on via serial API |
 | **Edge cases** | 2 | Invalid action handling; firstStart auto-clear flag |
+| **NVS persistence** | 13 | Config survives reboot; per-field persistence; defaults validation |
+| **NVS upgrade** | 1 | v1.0.0 blob → key-value migration via OTA (includes known brightness bug) |
 
-**Total: 18 tests**
+**Total: 32 tests**
 
 ## Safety
 
@@ -93,7 +120,11 @@ fails.
 ## Test Structure
 
 ```
-conftest.py          — Hub connection class, auto-detection, pytest fixtures
-test_serial_api.py   — Serial API test cases
-requirements.txt     — Python dependencies
+conftest.py               — Pytest fixtures, hub connection, CLI options
+hub.py                    — Hub class and device discovery (reusable outside pytest)
+test_serial_api.py        — Serial API test cases
+test_nvs_persistence.py   — NVS config persistence across reboots
+test_nvs_upgrade.py       — NVS migration from v1.0.0 to current firmware
+requirements.txt          — Python dependencies
+snapshots/                — Config snapshots from upgrade test runs
 ```

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/README.md
@@ -13,9 +13,15 @@ serial command interface.
 
 ```bash
 cd USBInsightHub-A1/UIH-ESP32S3/test/integration
-python3 -m venv .venv #or py -m venv .venv on Windows
-source .venv/bin/activate   # or .venv\Scripts\activate on Windows
-pip install -r requirements.txt
+./setup.sh
+```
+
+This creates the Python venv and installs dependencies.
+
+Manual setup (or Windows):
+```bash
+python3 -m venv .venv  # or py -m venv .venv on Windows
+.venv/bin/pip install -r requirements.txt  # or .venv\Scripts\pip on Windows
 ```
 
 ## Running Tests

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/conftest.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/conftest.py
@@ -1,127 +1,46 @@
-import json
 import logging
-import time
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 import serial
-from serial.tools.list_ports import comports
 
-log = logging.getLogger("hub")
-
-INSIGHT_HUB_VID = 0x303A
-INSIGHT_HUB_PID = 0x1001
-INSIGHT_HUB_PRODUCT = "InsightHUB Controller"
+from hub import Hub, HubConnectionError, find_hub
 
 LOGS_DIR = Path(__file__).parent / "logs"
 
-CONNECT_ATTEMPTS = 3
-CONNECT_SETTLE_S = 0.5
 
-
-def find_hub():
-    for p in comports():
-        if p.product == INSIGHT_HUB_PRODUCT or (
-            p.vid == INSIGHT_HUB_VID and p.pid == INSIGHT_HUB_PID
-        ):
-            return p.device
-    return None
-
-
-class HubConnectionError(Exception):
-    pass
-
-
-class Hub:
-    """Thin wrapper around the Insight Hub's JSON serial API."""
-
-    def __init__(self, port, timeout=2.0):
-        self.port = port
-        self.timeout = timeout
-        self.ser = None
-        self._connect()
-        self._verify_responsive()
-
-    def _connect(self):
-        log.info("Opening %s (timeout=%.1fs)", self.port, self.timeout)
-        if self.ser and self.ser.is_open:
-            self.ser.close()
-        self.ser = serial.Serial(self.port, 115200, timeout=self.timeout)
-        self.ser.dtr = True
-        time.sleep(CONNECT_SETTLE_S)
-        self.ser.reset_input_buffer()
-        log.info("Opened %s", self.port)
-
-    def _dtr_reset(self):
-        """Toggle DTR to trigger a CDC reconnect on the ESP32-S3."""
-        log.info("DTR reset on %s", self.port)
-        self.ser.dtr = False
-        time.sleep(0.1)
-        self.ser.dtr = True
-        time.sleep(CONNECT_SETTLE_S)
-        self.ser.reset_input_buffer()
-
-    def _verify_responsive(self):
-        """Probe the hub with a simple get; retry with DTR reset if needed."""
-        for attempt in range(1, CONNECT_ATTEMPTS + 1):
-            log.info("Connection check attempt %d/%d", attempt, CONNECT_ATTEMPTS)
-            resp = self.send({"action": "get", "params": ["hubMode"]})
-            if resp and resp.get("status") == "ok":
-                log.info("Hub responsive on attempt %d", attempt)
-                return
-            if attempt < CONNECT_ATTEMPTS:
-                log.warning("Hub not responding, retrying with DTR reset...")
-                self._dtr_reset()
-
-        raise HubConnectionError(
-            f"Hub on {self.port} not responding after {CONNECT_ATTEMPTS} attempts. "
-            f"Try power-cycling the hub (unplug/replug USB)."
-        )
-
-    def send(self, msg):
-        payload = json.dumps(msg, separators=(",", ":")) + "\n"
-        log.debug("TX: %s", payload.rstrip())
-        self.ser.write(payload.encode())
-        self.ser.flush()
-        line = self.ser.readline().decode("utf-8", errors="replace").strip()
-        if line:
-            log.debug("RX: %s", line)
-            try:
-                return json.loads(line)
-            except json.JSONDecodeError:
-                log.warning("RX not valid JSON: %r", line)
-                return None
-        log.debug("RX: (timeout, no response)")
-        return None
-
-    def get(self, *params):
-        resp = self.send({"action": "get", "params": list(params)})
-        if resp and resp.get("status") == "ok":
-            return resp.get("data", {})
-        log.warning("get(%s) failed: %r", params, resp)
-        return None
-
-    def set(self, params):
-        resp = self.send({"action": "set", "params": params})
-        ok = resp and resp.get("status") == "ok"
-        if not ok:
-            log.warning("set(%s) failed: %r", params, resp)
-        return ok
-
-    def close(self):
-        if self.ser and self.ser.is_open:
-            self.ser.close()
+PROJECT_DIR = Path(__file__).parent.parent.parent  # UIH-ESP32S3/
 
 
 def pytest_addoption(parser):
     parser.addoption(
         "--port", default=None, help="Serial port for Insight Hub (auto-detect if omitted)"
     )
+    parser.addoption(
+        "--quick", action="store_true", default=False,
+        help="Skip slow tests (restart, bootloader recovery)",
+    )
+    parser.addoption(
+        "--host", default=None,
+        help="Hub hostname/IP for OTA upgrade tests (e.g. insighthub.local)",
+    )
+    parser.addoption(
+        "--old-firmware",
+        default=str(PROJECT_DIR / "build" / "firmware" / "USBInsightHub-A0_esp32-s3-uih_1-0-0.bin"),
+        help="Path to v1.0.0 firmware binary (for upgrade tests)",
+    )
+    parser.addoption(
+        "--new-firmware",
+        default=str(PROJECT_DIR / ".pio" / "build" / "esp32-s3-uih" / "firmware.bin"),
+        help="Path to current firmware binary (for upgrade tests)",
+    )
 
 
 def pytest_configure(config):
-    """Set up file logging for every test run."""
+    """Set up file logging and custom markers."""
+    config.addinivalue_line("markers", "slow: marks tests that reboot the hub or take >10s")
+
     LOGS_DIR.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     logfile = LOGS_DIR / f"run-{timestamp}.log"
@@ -154,6 +73,12 @@ def pytest_collection_modifyitems(session, config, items):
         config._hub_instance = Hub(port)
     except (HubConnectionError, serial.SerialException) as e:
         pytest.exit(f"ERROR: {e}", returncode=1)
+
+    if config.getoption("--quick"):
+        skip_slow = pytest.mark.skip(reason="skipped by --quick")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
 
 
 @pytest.fixture(scope="session")

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/hub.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/hub.py
@@ -1,0 +1,399 @@
+"""Hub connection class and device discovery utilities.
+
+This module is independent of pytest and can be used by any test or script
+that needs to communicate with the Insight Hub over serial.
+"""
+
+import json
+import logging
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import serial
+from serial.tools.list_ports import comports
+
+log = logging.getLogger("hub")
+
+INSIGHT_HUB_VID = 0x303A
+INSIGHT_HUB_PID = 0x1001
+INSIGHT_HUB_PRODUCT = "InsightHUB Controller"
+BOOTLOADER_PRODUCT = "USB JTAG/serial debug unit"
+
+CONNECT_ATTEMPTS = 3
+CONNECT_SETTLE_S = 0.5
+
+# NVS partition layout (from partition_uih_8MB.csv)
+NVS_OFFSET = 0x9000
+NVS_SIZE = 0x5000
+
+
+def find_hub():
+    """Find the Insight Hub's serial port by USB VID/PID or product string."""
+    for p in comports():
+        if p.product == BOOTLOADER_PRODUCT:
+            continue
+        if p.product == INSIGHT_HUB_PRODUCT or (
+            p.vid == INSIGHT_HUB_VID and p.pid == INSIGHT_HUB_PID
+        ):
+            return p.device
+    return None
+
+
+def find_bootloader():
+    """Find an ESP32-S3 ROM bootloader serial port.
+
+    WARNING: If multiple ESP32-S3 devices are connected (e.g. hub + collar),
+    this may return the wrong one. Use --port to specify explicitly when
+    multiple devices are present.
+    """
+    for p in comports():
+        if p.product == BOOTLOADER_PRODUCT and p.vid == INSIGHT_HUB_VID:
+            return p.device
+    return None
+
+
+def find_esptool():
+    """Find esptool.py via PATH, then PlatformIO discovery."""
+    for name in ("esptool.py", "esptool"):
+        found = shutil.which(name)
+        if found:
+            return found
+    pio = shutil.which("pio") or shutil.which("platformio")
+    if pio:
+        try:
+            r = subprocess.run(
+                [pio, "system", "info", "--json-output"],
+                capture_output=True, text=True, timeout=10,
+            )
+            info = json.loads(r.stdout)
+            core_dir_entry = info.get("core_dir", {})
+            core_dir_str = (core_dir_entry.get("value", "")
+                           if isinstance(core_dir_entry, dict)
+                           else str(core_dir_entry))
+            core_dir = Path(core_dir_str)
+            for candidate in [
+                core_dir / "packages" / "tool-esptoolpy" / "esptool.py",
+                core_dir / "penv" / "bin" / "esptool.py",
+                core_dir / "penv" / "Scripts" / "esptool.py",
+            ]:
+                if candidate.exists():
+                    return str(candidate)
+        except Exception:
+            pass
+    return None
+
+
+def _find_pio_python():
+    """Return PlatformIO's bundled Python interpreter path."""
+    pio_python = Path.home() / ".platformio" / "penv" / "bin" / "python3"
+    return str(pio_python) if pio_python.exists() else "python3"
+
+
+class HubConnectionError(Exception):
+    pass
+
+
+class Hub:
+    """Thin wrapper around the Insight Hub's JSON serial API."""
+
+    def __init__(self, port, timeout=2.0):
+        self.port = port
+        self.timeout = timeout
+        self.ser = None
+        self._connect()
+        self._verify_responsive()
+
+    def _connect(self):
+        log.info("Opening %s (timeout=%.1fs)", self.port, self.timeout)
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+        self.ser = serial.Serial(self.port, 115200, timeout=self.timeout)
+        self.ser.dtr = True
+        time.sleep(CONNECT_SETTLE_S)
+        self.ser.reset_input_buffer()
+        log.info("Opened %s", self.port)
+
+    def _dtr_reset(self):
+        """Toggle DTR to trigger a CDC reconnect on the ESP32-S3."""
+        log.info("DTR reset on %s", self.port)
+        self.ser.dtr = False
+        time.sleep(0.1)
+        self.ser.dtr = True
+        time.sleep(CONNECT_SETTLE_S)
+        self.ser.reset_input_buffer()
+
+    def _verify_responsive(self):
+        """Probe the hub with a simple get; retry with DTR reset if needed."""
+        for attempt in range(1, CONNECT_ATTEMPTS + 1):
+            log.info("Connection check attempt %d/%d", attempt, CONNECT_ATTEMPTS)
+            resp = self.send({"action": "get", "params": ["hubMode"]})
+            if resp and resp.get("status") == "ok":
+                log.info("Hub responsive on attempt %d", attempt)
+                return
+            if attempt < CONNECT_ATTEMPTS:
+                log.warning("Hub not responding, retrying with DTR reset...")
+                self._dtr_reset()
+
+        raise HubConnectionError(
+            f"Hub on {self.port} not responding after {CONNECT_ATTEMPTS} attempts. "
+            f"Try power-cycling the hub (unplug/replug USB)."
+        )
+
+    def send(self, msg):
+        payload = json.dumps(msg, separators=(",", ":")) + "\n"
+        log.debug("TX: %s", payload.rstrip())
+        self.ser.write(payload.encode())
+        self.ser.flush()
+        line = self.ser.readline().decode("utf-8", errors="replace").strip()
+        if line:
+            log.debug("RX: %s", line)
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("RX not valid JSON: %r", line)
+                return None
+        log.debug("RX: (timeout, no response)")
+        return None
+
+    def get(self, *params):
+        resp = self.send({"action": "get", "params": list(params)})
+        if resp and resp.get("status") == "ok":
+            return resp.get("data", {})
+        log.warning("get(%s) failed: %r", params, resp)
+        return None
+
+    def set(self, params):
+        resp = self.send({"action": "set", "params": params})
+        ok = resp and resp.get("status") == "ok"
+        if not ok:
+            log.warning("set(%s) failed: %r", params, resp)
+        return ok
+
+    def reconnect(self, timeout=30.0, poll_interval=0.5):
+        """Wait for hub to reboot, then reconnect.
+
+        Phase 1: wait up to 5s for the USB port to disappear (the hub
+        may or may not disconnect depending on reset type — ESP32-S3
+        USB-JTAG/Serial stays powered through software resets).
+
+        Phase 2: poll until the application port appears and the hub
+        responds to a command.
+        """
+        log.info("Reconnecting (timeout=%.1fs)", timeout)
+        self.close()
+        deadline = time.monotonic() + timeout
+
+        # Phase 1: brief wait for port to disappear (may not happen)
+        phase1_deadline = min(time.monotonic() + 5.0, deadline)
+        while time.monotonic() < phase1_deadline:
+            if not find_hub():
+                log.info("Hub disconnected from USB")
+                break
+            time.sleep(poll_interval)
+
+        # Phase 2: wait for the port to (re)appear
+        port = None
+        while time.monotonic() < deadline:
+            port = find_hub()
+            if port:
+                break
+            time.sleep(poll_interval)
+        if not port:
+            raise HubConnectionError(
+                f"Hub did not re-enumerate within {timeout}s"
+            )
+        log.info("Hub re-enumerated on %s", port)
+        self.port = port
+        self._connect()
+        self._verify_responsive()
+
+    def touch_1200(self):
+        """Open port at 1200 baud to trigger bootloader entry.
+
+        Requires reboot_enabled=1 to be set first.
+        """
+        log.info("1200-baud touch on %s", self.port)
+        self.close()
+        s = serial.Serial(self.port, 1200)
+        time.sleep(0.5)
+        s.close()
+        time.sleep(2.0)
+
+    def boot_from_bootloader(self):
+        """Exit ROM bootloader via esptool hard reset.
+
+        Clears FORCE_DOWNLOAD_BOOT via write_mem and triggers a hard reset
+        so the chip boots the application.
+        """
+        bl_port = find_bootloader()
+        if not bl_port:
+            app_port = find_hub()
+            if app_port:
+                log.info("Hub already running (not in bootloader) on %s", app_port)
+                self.port = app_port
+                self._connect()
+                self._verify_responsive()
+                return
+            raise HubConnectionError(
+                "Hub not found — neither bootloader nor application port detected."
+            )
+        log.info("Recovering from bootloader on %s", bl_port)
+        self.close()
+
+        esptool_path = find_esptool()
+        if not esptool_path:
+            raise RuntimeError("esptool not found — cannot recover from bootloader.")
+
+        pio_python = _find_pio_python()
+
+        log.info("Clearing FORCE_DOWNLOAD_BOOT and resetting on %s", bl_port)
+        cmd = [pio_python, esptool_path,
+               "--port", bl_port, "--chip", "esp32s3",
+               "--no-stub", "--after", "hard_reset",
+               "write_mem", "0x6000812C", "0x0", "0x1"]
+        log.debug("Running: %s", " ".join(cmd))
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        log.debug("esptool stdout: %s", r.stdout.strip())
+        if r.returncode != 0:
+            log.warning("esptool stderr: %s", r.stderr.strip())
+            raise RuntimeError(
+                f"esptool write_mem failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
+        time.sleep(1.0)
+
+        deadline = time.monotonic() + 30.0
+        port = None
+        while time.monotonic() < deadline:
+            port = find_hub()
+            if port:
+                break
+            time.sleep(0.5)
+        if not port:
+            raise HubConnectionError(
+                "Hub did not re-enumerate after hard reset. "
+                "Try unplugging and replugging the hub."
+            )
+        log.info("Hub re-enumerated on %s after hard reset", port)
+        self.port = port
+        self._connect()
+        self._verify_responsive()
+
+    def dump_nvs(self, output_path):
+        """Dump NVS partition to a binary file via esptool.
+
+        Enters bootloader mode (1200-baud touch), reads flash, then
+        exits bootloader back to the application.
+
+        Requires reboot_enabled=1 to be set first.
+        """
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        esptool_path = find_esptool()
+        if not esptool_path:
+            raise RuntimeError("esptool not found — cannot dump NVS.")
+        pio_python = _find_pio_python()
+
+        # Enter bootloader
+        log.info("Entering bootloader for NVS dump")
+        self.touch_1200()
+
+        bl_port = None
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            bl_port = find_bootloader()
+            if bl_port:
+                break
+            time.sleep(0.5)
+        if not bl_port:
+            raise HubConnectionError("Bootloader port not found after 1200-baud touch")
+
+        # Read NVS partition
+        log.info("Reading NVS partition (0x%X, %d bytes) from %s",
+                 NVS_OFFSET, NVS_SIZE, bl_port)
+        cmd = [pio_python, esptool_path,
+               "--port", bl_port, "--chip", "esp32s3",
+               "--no-stub", "--after", "no_reset",
+               "read_flash", hex(NVS_OFFSET), hex(NVS_SIZE), str(output_path)]
+        log.debug("Running: %s", " ".join(cmd))
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        log.debug("esptool stdout: %s", r.stdout.strip())
+        if r.returncode != 0:
+            log.warning("esptool stderr: %s", r.stderr.strip())
+            raise RuntimeError(
+                f"esptool read_flash failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
+        log.info("NVS dump saved to %s (%d bytes)",
+                 output_path, output_path.stat().st_size)
+
+        # Exit bootloader, return to app
+        self.boot_from_bootloader()
+
+    def restore_nvs(self, input_path):
+        """Restore NVS partition from a binary file via esptool.
+
+        Enters bootloader mode (1200-baud touch), writes flash, then
+        exits bootloader back to the application.
+
+        Requires reboot_enabled=1 to be set first.
+        """
+        input_path = Path(input_path)
+        if not input_path.exists():
+            raise FileNotFoundError(f"NVS snapshot not found: {input_path}")
+
+        esptool_path = find_esptool()
+        if not esptool_path:
+            raise RuntimeError("esptool not found — cannot restore NVS.")
+        pio_python = _find_pio_python()
+
+        # Enter bootloader
+        log.info("Entering bootloader for NVS restore")
+        self.touch_1200()
+
+        bl_port = None
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            bl_port = find_bootloader()
+            if bl_port:
+                break
+            time.sleep(0.5)
+        if not bl_port:
+            raise HubConnectionError("Bootloader port not found after 1200-baud touch")
+
+        # Write NVS partition
+        log.info("Writing NVS partition (0x%X) from %s to %s",
+                 NVS_OFFSET, input_path, bl_port)
+        cmd = [pio_python, esptool_path,
+               "--port", bl_port, "--chip", "esp32s3",
+               "--no-stub", "--after", "hard_reset",
+               "write_flash", hex(NVS_OFFSET), str(input_path)]
+        log.debug("Running: %s", " ".join(cmd))
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        log.debug("esptool stdout: %s", r.stdout.strip())
+        if r.returncode != 0:
+            log.warning("esptool stderr: %s", r.stderr.strip())
+            raise RuntimeError(
+                f"esptool write_flash failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
+        log.info("NVS restored from %s", input_path)
+
+        # Wait for app to boot after hard reset
+        time.sleep(1.0)
+        deadline = time.monotonic() + 30.0
+        port = None
+        while time.monotonic() < deadline:
+            port = find_hub()
+            if port:
+                break
+            time.sleep(0.5)
+        if not port:
+            raise HubConnectionError("Hub did not re-enumerate after NVS restore")
+        self.port = port
+        self._connect()
+        self._verify_responsive()
+
+    def close(self):
+        if self.ser and self.ser.is_open:
+            self.ser.close()

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/requirements.txt
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/requirements.txt
@@ -1,3 +1,4 @@
 pyserial>=3.5
 pytest>=7.0
 pytest-html>=4.0
+requests>=2.28

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/setup.sh
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Create or update the test virtual environment.
+set -euo pipefail
+cd "$(dirname "$0")"
+[ -d .venv ] || python3 -m venv .venv
+.venv/bin/pip install -q -r requirements.txt

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/setup.sh
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Create or update the test virtual environment.
+# Set up the development environment for integration tests.
 set -euo pipefail
+
 cd "$(dirname "$0")"
 [ -d .venv ] || python3 -m venv .venv
 .venv/bin/pip install -q -r requirements.txt

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/snapshots/README.md
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/snapshots/README.md
@@ -1,0 +1,102 @@
+# NVS Upgrade Snapshots
+
+Config snapshots captured during `test_nvs_upgrade.py` runs. Two types of
+snapshot are saved:
+
+- **JSON** (`.json`) — human-readable config values read via the serial API
+- **Binary** (`.bin`) — raw NVS partition dump read via esptool in bootloader mode
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `v1.0.0-defaults.json` | Config immediately after flashing v1.0.0 (factory defaults) |
+| `v1.0.0-modified.json` | Config after setting non-default values on v1.0.0 |
+| `post-upgrade.json` | Config after OTA to the current firmware (post-migration) |
+| `post-upgrade-nvs.bin` | Raw NVS partition after migration (for reverting) |
+
+## How they're created
+
+The upgrade test (`test_nvs_upgrade.py`) runs these steps:
+
+1. OTA flash v1.0.0 firmware
+2. Read all config via serial API &rarr; `v1.0.0-defaults.json`
+3. Set test values (filterType, refreshRate, hubMode, brightness, per-channel limits)
+4. Read config again &rarr; `v1.0.0-modified.json`
+5. OTA flash current firmware (triggers legacy blob &rarr; key-value migration)
+6. Read config again &rarr; `post-upgrade.json`
+7. Enable `reboot_enabled`, enter bootloader via 1200-baud touch, dump NVS
+   partition via esptool `read_flash` &rarr; `post-upgrade-nvs.bin`
+8. Exit bootloader (hard reset back to app)
+
+The test then asserts that values from step 3 survived in step 6, and that
+new fields (e.g. `reboot_enabled`) have their expected defaults.
+
+## Capturing and reverting NVS snapshots
+
+The hub must be in ROM bootloader mode for these operations. To enter
+bootloader: set `reboot_enabled=1` (via serial API, web UI, or on-board
+menu), then perform a 1200-baud touch on the serial port.
+
+### Using the helper scripts
+
+```bash
+# Enter bootloader first (from a serial terminal or Python):
+#   {"action":"set","params":{"reboot_enabled":1}}
+#   then 1200-baud touch
+
+# List ports to find the bootloader device
+python3 -m serial.tools.list_ports -v
+
+# Dump current NVS (port is required — no auto-detect)
+./scripts/nvs_dump.sh /dev/cu.usbmodemXXX
+./scripts/nvs_dump.sh /dev/cu.usbmodemXXX my-snapshot.bin
+
+# Restore a previous snapshot (reboots hub into app automatically)
+./scripts/nvs_restore.sh /dev/cu.usbmodemXXX my-snapshot.bin
+```
+
+### Using the test framework (Python)
+
+```python
+from hub import Hub, find_hub
+
+hub = Hub(find_hub())
+hub.set({"reboot_enabled": 1})   # enable bootloader entry
+hub.dump_nvs("my-snapshot.bin")  # enters bootloader, dumps, returns to app
+hub.restore_nvs("my-snapshot.bin")  # enters bootloader, writes, reboots
+```
+
+### Using esptool directly
+
+```bash
+# Dump NVS (stays in bootloader after reading)
+esptool.py --port /dev/cu.usbmodemXXX --chip esp32s3 --no-stub \
+    --after no_reset \
+    read_flash 0x9000 0x5000 my-snapshot.bin
+
+# Restore NVS (hard resets into app after writing)
+esptool.py --port /dev/cu.usbmodemXXX --chip esp32s3 --no-stub \
+    --after hard_reset \
+    write_flash 0x9000 my-snapshot.bin
+
+# Exit bootloader without writing anything
+esptool.py --port /dev/cu.usbmodemXXX --chip esp32s3 --no-stub \
+    --after hard_reset \
+    write_mem 0x6000812C 0x0 0x1
+```
+
+## NVS partition layout
+
+From `partition_uih_8MB.csv`:
+
+| Name | Offset | Size |
+|------|--------|------|
+| nvs | 0x9000 | 0x5000 (20 KB) |
+
+## Future work
+
+A serial API command for NVS dump/restore would eliminate the need to enter
+bootloader mode, making this accessible to end users without esptool. The
+binary format would be identical — same NVS partition bytes, different
+transport.

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_persistence.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_persistence.py
@@ -1,0 +1,287 @@
+"""Integration tests for NVS config persistence across reboots.
+
+Verifies that configuration changes survive a device restart, covering
+the issue described in GitHub #10 (NVS config blob migration resets all
+settings when adding new fields).
+
+These tests are slow (each reboot cycle takes ~10-30s) and are intended
+to be run before releases, not on every commit.
+
+Usage:
+    .venv/bin/pytest test_nvs_persistence.py -v
+    .venv/bin/pytest test_nvs_persistence.py -v --port /dev/cu.usbmodemXXX
+    .venv/bin/pytest test_nvs_persistence.py -v --quick   # skip reboot tests
+"""
+
+import time
+
+import pytest
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+# Config fields returned by get("config") and their non-default test values.
+CONFIG_FIELDS = {
+    "filterType":     ("moving_avg", str),   # default is "median"
+    "refreshRate":    ("1.0s",       str),   # default is "0.5s"
+    "brightness":     (50,           int),   # API accepts 5-100 (%)
+    "reboot_enabled": (0,            int),   # default is 0 (DISABLE)
+}
+
+# Per-channel config fields (via CHx_all) with non-default test values.
+CHANNEL_FIELDS = {
+    "fwdLimit":    (500,  int),   # default 1000
+    "backLimit":   (50,   int),   # default 20
+    "startup_tmr": (42,   int),   # defaults 10/20/30
+}
+
+
+def snapshot_config(hub):
+    """Capture all persistent config values from the device."""
+    snap = {}
+    data = hub.get("config")
+    assert data is not None, "get('config') returned None"
+    for key in CONFIG_FIELDS:
+        snap[key] = data.get(key)
+
+    for ch_idx in range(1, 4):
+        ch = f"CH{ch_idx}"
+        data = hub.get(f"{ch}_all")
+        assert data is not None and ch in data, f"get('{ch}_all') failed"
+        for key in CHANNEL_FIELDS:
+            snap[f"{ch}.{key}"] = data[ch].get(key)
+
+    return snap
+
+
+def apply_test_config(hub):
+    """Set all config fields to non-default test values."""
+    params = {}
+    for key, (val, _) in CONFIG_FIELDS.items():
+        params[key] = val
+    ok = hub.set(params)
+    assert ok, f"set({params}) failed"
+
+    for ch_idx in range(1, 4):
+        ch = f"CH{ch_idx}"
+        ch_params = {}
+        for key, (val, _) in CHANNEL_FIELDS.items():
+            ch_params[key] = val
+        ok = hub.set({ch: ch_params})
+        assert ok, f"set({ch}: {ch_params}) failed"
+
+    # Allow auto-save task to persist (runs every 100ms)
+    time.sleep(0.5)
+
+
+def expected_test_snapshot():
+    """Build the expected snapshot after apply_test_config."""
+    snap = {}
+    for key, (val, _) in CONFIG_FIELDS.items():
+        snap[key] = val
+    for ch_idx in range(1, 4):
+        ch = f"CH{ch_idx}"
+        for key, (val, _) in CHANNEL_FIELDS.items():
+            snap[f"{ch}.{key}"] = val
+    return snap
+
+
+# ── Tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.slow
+class TestNvsPersistenceAcrossReboot:
+    """Config values set via serial API survive a software restart."""
+
+    @pytest.fixture(autouse=True)
+    def _save_and_restore(self, hub):
+        """Capture config before test, restore after."""
+        self._orig = snapshot_config(hub)
+        yield
+        # Restore original values
+        restore_global = {}
+        for key in CONFIG_FIELDS:
+            if self._orig[key] is not None:
+                restore_global[key] = self._orig[key]
+        if restore_global:
+            hub.set(restore_global)
+
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            ch_params = {}
+            for key in CHANNEL_FIELDS:
+                orig_val = self._orig.get(f"{ch}.{key}")
+                if orig_val is not None:
+                    ch_params[key] = orig_val
+            if ch_params:
+                hub.set({ch: ch_params})
+
+        time.sleep(0.5)  # let auto-save persist the restore
+
+    def test_config_survives_restart(self, hub):
+        """All config fields retain their values after a software restart."""
+        # 1. Apply non-default values
+        apply_test_config(hub)
+
+        # 2. Verify they took effect before reboot
+        pre_reboot = snapshot_config(hub)
+        expected = expected_test_snapshot()
+        for key, exp_val in expected.items():
+            assert pre_reboot[key] == exp_val, (
+                f"Pre-reboot: {key} = {pre_reboot[key]!r}, expected {exp_val!r}"
+            )
+
+        # 3. Restart the device
+        hub.send({"action": "restart", "params": {"immediate": True}})
+        hub.reconnect(timeout=30.0)
+
+        # 4. Read back and compare
+        post_reboot = snapshot_config(hub)
+        mismatches = []
+        for key, exp_val in expected.items():
+            actual = post_reboot[key]
+            if actual != exp_val:
+                mismatches.append(f"  {key}: expected {exp_val!r}, got {actual!r}")
+
+        assert not mismatches, (
+            "Config values changed after reboot:\n" + "\n".join(mismatches)
+        )
+
+
+@pytest.mark.slow
+class TestNvsIndividualFieldPersistence:
+    """Each settable config field individually survives a reboot.
+
+    Parametrized so failures pinpoint the exact field that didn't persist.
+    """
+
+    @pytest.mark.parametrize("field,test_val", [
+        ("filterType", "moving_avg"),
+        ("refreshRate", "1.0s"),
+        ("brightness", 50),
+    ])
+    def test_global_field(self, hub, field, test_val):
+        """Global config field persists across reboot."""
+        # Save original
+        orig_data = hub.get(field)
+        orig_val = orig_data.get(field) if orig_data else None
+
+        try:
+            # Set test value
+            assert hub.set({field: test_val}), f"set({field}={test_val}) failed"
+            time.sleep(0.5)
+
+            # Verify pre-reboot
+            data = hub.get(field)
+            assert data.get(field) == test_val, (
+                f"Pre-reboot: {field} = {data.get(field)!r}, expected {test_val!r}"
+            )
+
+            # Reboot
+            hub.send({"action": "restart", "params": {"immediate": True}})
+            hub.reconnect(timeout=30.0)
+
+            # Verify post-reboot
+            data = hub.get(field)
+            assert data.get(field) == test_val, (
+                f"Post-reboot: {field} = {data.get(field)!r}, expected {test_val!r}"
+            )
+        finally:
+            # Restore
+            if orig_val is not None:
+                hub.set({field: orig_val})
+                time.sleep(0.3)
+
+    @pytest.mark.parametrize("field,test_val", [
+        ("fwdLimit", 500),
+        ("backLimit", 50),
+        ("startup_tmr", 42),
+    ])
+    def test_channel_field(self, hub, field, test_val):
+        """Per-channel config field (CH1) persists across reboot."""
+        ch = "CH1"
+
+        # Save original
+        orig_data = hub.get(f"{ch}_all")
+        orig_val = orig_data[ch].get(field) if orig_data and ch in orig_data else None
+
+        try:
+            # Set test value
+            assert hub.set({ch: {field: test_val}}), f"set({ch}.{field}={test_val}) failed"
+            time.sleep(0.5)
+
+            # Verify pre-reboot
+            data = hub.get(f"{ch}_all")
+            assert data[ch].get(field) == test_val, (
+                f"Pre-reboot: {ch}.{field} = {data[ch].get(field)!r}, expected {test_val!r}"
+            )
+
+            # Reboot
+            hub.send({"action": "restart", "params": {"immediate": True}})
+            hub.reconnect(timeout=30.0)
+
+            # Verify post-reboot
+            data = hub.get(f"{ch}_all")
+            assert data[ch].get(field) == test_val, (
+                f"Post-reboot: {ch}.{field} = {data[ch].get(field)!r}, expected {test_val!r}"
+            )
+        finally:
+            # Restore
+            if orig_val is not None:
+                hub.set({ch: {field: orig_val}})
+                time.sleep(0.3)
+
+
+class TestNvsDefaults:
+    """Verify factory default values match expected spec (no reboot needed)."""
+
+    def test_default_config_keys_present(self, hub):
+        """get('config') returns all expected keys."""
+        data = hub.get("config")
+        assert data is not None
+        expected_keys = [
+            "startUpmode", "wifi_enabled", "hubMode",
+            "filterType", "refreshRate", "brightness", "reboot_enabled",
+        ]
+        for key in expected_keys:
+            assert key in data, f"config missing key: {key}"
+
+    def test_channel_all_keys_present(self, hub):
+        """get('CHx_all') returns config fields for each channel."""
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            data = hub.get(f"{ch}_all")
+            assert data is not None and ch in data, f"{ch}_all query failed"
+            for key in ("fwdLimit", "backLimit", "startup_tmr", "ilim"):
+                assert key in data[ch], f"{ch}_all missing {key}"
+
+    def test_brightness_in_range(self, hub):
+        """Brightness percentage is within valid API range."""
+        data = hub.get("brightness")
+        val = data.get("brightness")
+        assert isinstance(val, int), f"brightness is {type(val)}, expected int"
+        assert 0 <= val <= 100, f"brightness {val} out of range [0, 100]"
+
+    def test_fwd_limit_in_range(self, hub):
+        """Forward current limit is within valid range for all channels."""
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            data = hub.get(f"{ch}_all")
+            val = data[ch]["fwdLimit"]
+            assert 100 <= val <= 2000, f"{ch} fwdLimit {val} out of range [100,2000]"
+
+    def test_back_limit_in_range(self, hub):
+        """Back current limit is within valid range for all channels."""
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            data = hub.get(f"{ch}_all")
+            val = data[ch]["backLimit"]
+            assert 1 <= val <= 200, f"{ch} backLimit {val} out of range [1,200]"
+
+    def test_uptime_available(self, hub):
+        """Uptime (millis) is reported and positive."""
+        data = hub.get("uptime")
+        assert data is not None
+        val = data.get("uptime")
+        assert isinstance(val, int) and val > 0, f"uptime = {val!r}"

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
@@ -1,0 +1,310 @@
+"""Integration test for NVS config migration across firmware upgrades.
+
+Verifies that user settings survive an OTA firmware upgrade from v1.0.0
+(blob-based NVS) to the current firmware (key-value NVS), and that new
+config fields introduced in the current firmware receive correct defaults.
+
+This test is destructive: it flashes old firmware, changes settings, then
+flashes the current firmware. Run it manually before releases — not in CI.
+
+Covers GitHub issue #10.
+
+Prerequisites:
+    - Hub connected via USB serial (for config reads/writes)
+    - Hub connected to WiFi (for OTA upload)
+    - v1.0.0 firmware binary available (checked into build/firmware/)
+    - Current firmware binary already built (pio run)
+
+Usage:
+    .venv/bin/pytest test_nvs_upgrade.py -v -s \\
+        --host insighthub.local \\
+        --old-firmware build/firmware/USBInsightHub-A0_esp32-s3-uih_1-0-0.bin
+
+    # Or with explicit new firmware path:
+    .venv/bin/pytest test_nvs_upgrade.py -v -s \\
+        --host 192.168.4.1 \\
+        --old-firmware build/firmware/USBInsightHub-A0_esp32-s3-uih_1-0-0.bin \\
+        --new-firmware .pio/build/esp32-s3-uih/firmware.bin
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+log = logging.getLogger("hub")
+
+SNAPSHOTS_DIR = Path(__file__).parent / "snapshots"
+
+
+# ── OTA helpers ─────────────────────────────────────────────────
+
+DEFAULT_ADMIN_USER = "admin"
+DEFAULT_ADMIN_PASS = "admin"
+OTA_TIMEOUT_S = 120
+REBOOT_WAIT_S = 15
+
+
+def get_auth_token(host, username=DEFAULT_ADMIN_USER, password=DEFAULT_ADMIN_PASS):
+    """Authenticate with the hub's REST API and return a JWT bearer token."""
+    url = f"http://{host}/rest/signIn"
+    resp = requests.post(url, json={"username": username, "password": password}, timeout=10)
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def ota_upload(host, firmware_path, token):
+    """Upload firmware via OTA and wait for the hub to reboot."""
+    url = f"http://{host}/rest/uploadFirmware"
+    fw_path = Path(firmware_path)
+    assert fw_path.exists(), f"Firmware not found: {fw_path}"
+
+    size = fw_path.stat().st_size
+    log.info("OTA upload: %s (%d bytes) → %s", fw_path.name, size, host)
+
+    with open(fw_path, "rb") as f:
+        resp = requests.post(
+            url,
+            files={"file": (fw_path.name, f, "application/octet-stream")},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=OTA_TIMEOUT_S,
+        )
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"OTA upload failed: HTTP {resp.status_code} — {resp.text}"
+        )
+    log.info("OTA upload accepted — hub is rebooting")
+
+
+def save_snapshot(name, data):
+    """Save a config snapshot to a JSON file for post-mortem analysis."""
+    SNAPSHOTS_DIR.mkdir(parents=True, exist_ok=True)
+    path = SNAPSHOTS_DIR / f"{name}.json"
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    log.info("Saved snapshot: %s", path)
+    return path
+
+
+def save_nvs_snapshot(hub, name):
+    """Dump the NVS partition to a binary file via bootloader + esptool."""
+    SNAPSHOTS_DIR.mkdir(parents=True, exist_ok=True)
+    path = SNAPSHOTS_DIR / f"{name}.bin"
+    hub.dump_nvs(path)
+    return path
+
+
+# ── Config capture ──────────────────────────────────────────────
+
+def snapshot_full_config(hub):
+    """Capture all config + channel fields via serial API."""
+    snap = {}
+
+    # Global config
+    data = hub.get("config")
+    assert data is not None, "get('config') returned None"
+    snap["config"] = data
+
+    # Per-channel extended data
+    for ch_idx in range(1, 4):
+        ch = f"CH{ch_idx}"
+        data = hub.get(f"{ch}_all")
+        assert data is not None and ch in data, f"get('{ch}_all') failed"
+        snap[ch] = data[ch]
+
+    # State (for version, uptime)
+    state = hub.get("state")
+    if state:
+        snap["state"] = state
+
+    return snap
+
+
+# ── v1.0.0 config fields (no reboot_enabled, no uptime) ────────
+# These are the fields we can set on v1.0.0 via its serial API and
+# expect to survive migration to the new firmware.
+V1_TEST_CONFIG = {
+    # Global config (set action params)
+    "filterType": "moving_avg",   # default: "median"
+    "refreshRate": "1.0s",        # default: "0.5s"
+    "hubMode": "usb2",            # default: "usb2&3"
+    "brightness": 50,             # default: 800 (raw PWM on v1.0.0)
+    # NOTE: v1.0.0 stores brightness as raw 10-100 and returns it as-is.
+    # The current firmware stores brightness as 10-bit PWM internally
+    # (set converts %, get converts back). The legacy migration copies the
+    # raw value, so brightness=50 on v1.0.0 becomes PWM=50 on the new
+    # firmware, which the getter reports as ~5%. This is a known migration
+    # bug — this test should fail until it's fixed.
+}
+
+V1_TEST_CHANNEL_CONFIG = {
+    # Per-channel (set via CH1/CH2/CH3)
+    "fwdLimit": 500,    # default: 1000
+    "backLimit": 50,    # default: 20
+    "startup_tmr": 42,  # defaults: 10/20/30
+}
+
+# Fields that are NEW in the current firmware and should get defaults
+# when upgrading from v1.0.0 (the key won't exist in NVS).
+NEW_FIELDS_EXPECTED_DEFAULTS = {
+    "reboot_enabled": 0,   # DISABLE
+}
+
+
+# ── Tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.slow
+class TestNvsUpgradeMigration:
+    """Full upgrade path: v1.0.0 → current firmware."""
+
+    @pytest.fixture(autouse=True)
+    def _require_host(self, request):
+        """Skip if --host not provided (OTA requires WiFi)."""
+        self.host = request.config.getoption("--host", default=None)
+        if not self.host:
+            pytest.skip("--host required for OTA upgrade tests")
+        self.old_fw = request.config.getoption("--old-firmware")
+        self.new_fw = request.config.getoption("--new-firmware")
+
+    def _ota_flash_and_reconnect(self, hub, firmware_path, label):
+        """Flash firmware via OTA, wait, reconnect serial."""
+        token = get_auth_token(self.host)
+        ota_upload(self.host, firmware_path, token)
+        time.sleep(REBOOT_WAIT_S)
+        hub.reconnect(timeout=45.0)
+        log.info("Reconnected after %s OTA", label)
+
+    def test_upgrade_preserves_settings(self, hub):
+        """Settings changed on v1.0.0 survive migration to current firmware.
+
+        Steps:
+            1. OTA flash v1.0.0
+            2. Snapshot defaults (reference)
+            3. Change config to non-default values
+            4. Snapshot modified config (reference)
+            5. OTA flash current firmware (triggers legacy migration)
+            6. Verify old settings survived
+            7. Verify new fields have correct defaults
+        """
+        assert Path(self.old_fw).exists(), f"Old firmware not found: {self.old_fw}"
+        assert Path(self.new_fw).exists(), (
+            f"New firmware not found: {self.new_fw}\n"
+            f"Run 'pio run -e esp32-s3-uih' first."
+        )
+
+        # ── Step 1: Flash v1.0.0 ───────────────────────────────
+        log.info("=== Step 1: Flashing v1.0.0 ===")
+        self._ota_flash_and_reconnect(hub, self.old_fw, "v1.0.0")
+
+        # ── Step 2: Snapshot v1.0.0 defaults ────────────────────
+        log.info("=== Step 2: Capturing v1.0.0 defaults ===")
+        snap_defaults = snapshot_full_config(hub)
+        save_snapshot("v1.0.0-defaults", snap_defaults)
+
+        # ── Step 3: Change settings ─────────────────────────────
+        log.info("=== Step 3: Setting non-default config ===")
+
+        ok = hub.set(V1_TEST_CONFIG)
+        assert ok, f"Failed to set global config: {V1_TEST_CONFIG}"
+
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            ok = hub.set({ch: V1_TEST_CHANNEL_CONFIG})
+            assert ok, f"Failed to set {ch} config: {V1_TEST_CHANNEL_CONFIG}"
+
+        # Wait for auto-save (100ms task + margin)
+        time.sleep(1.0)
+
+        # ── Step 4: Snapshot modified config ────────────────────
+        log.info("=== Step 4: Capturing v1.0.0 modified config ===")
+        snap_modified = snapshot_full_config(hub)
+        save_snapshot("v1.0.0-modified", snap_modified)
+
+        # Verify changes took effect on v1.0.0
+        for key, val in V1_TEST_CONFIG.items():
+            actual = snap_modified["config"].get(key)
+            assert actual == val, (
+                f"v1.0.0 set failed: {key} = {actual!r}, expected {val!r}"
+            )
+
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            for key, val in V1_TEST_CHANNEL_CONFIG.items():
+                actual = snap_modified[ch].get(key)
+                assert actual == val, (
+                    f"v1.0.0 set failed: {ch}.{key} = {actual!r}, expected {val!r}"
+                )
+
+        # ── Step 5: Flash current firmware ──────────────────────
+        log.info("=== Step 5: Flashing current firmware (triggers migration) ===")
+        self._ota_flash_and_reconnect(hub, self.new_fw, "current")
+
+        # ── Step 6: Snapshot post-upgrade config ────────────────
+        log.info("=== Step 6: Capturing post-upgrade config ===")
+        snap_upgraded = snapshot_full_config(hub)
+        save_snapshot("post-upgrade", snap_upgraded)
+
+        # Dump NVS binary (requires reboot_enabled on current firmware).
+        # This enables reverting to this exact NVS state if needed.
+        hub.set({"reboot_enabled": 1})
+        time.sleep(0.5)
+        save_nvs_snapshot(hub, "post-upgrade-nvs")
+
+        # ── Step 7: Verify old settings survived ────────────────
+        log.info("=== Step 7: Verifying settings survived migration ===")
+        mismatches = []
+
+        for key, val in V1_TEST_CONFIG.items():
+            actual = snap_upgraded["config"].get(key)
+            if actual != val:
+                mismatches.append(
+                    f"  config.{key}: expected {val!r} (set on v1.0.0), got {actual!r}"
+                )
+
+        for ch_idx in range(1, 4):
+            ch = f"CH{ch_idx}"
+            for key, val in V1_TEST_CHANNEL_CONFIG.items():
+                actual = snap_upgraded[ch].get(key)
+                if actual != val:
+                    mismatches.append(
+                        f"  {ch}.{key}: expected {val!r} (set on v1.0.0), got {actual!r}"
+                    )
+
+        if mismatches:
+            pytest.fail(
+                "Settings lost during v1.0.0 → current migration:\n"
+                + "\n".join(mismatches)
+            )
+
+        # ── Step 8: Verify new fields have defaults ─────────────
+        log.info("=== Step 8: Verifying new field defaults ===")
+        new_field_issues = []
+
+        for key, expected_default in NEW_FIELDS_EXPECTED_DEFAULTS.items():
+            actual = snap_upgraded["config"].get(key)
+            if actual is None:
+                new_field_issues.append(
+                    f"  config.{key}: missing from response (expected {expected_default!r})"
+                )
+            elif actual != expected_default:
+                new_field_issues.append(
+                    f"  config.{key}: expected default {expected_default!r}, got {actual!r}"
+                )
+
+        if new_field_issues:
+            pytest.fail(
+                "New fields don't have correct defaults after migration:\n"
+                + "\n".join(new_field_issues)
+            )
+
+        # ── Step 9: Verify uptime is available (new feature) ────
+        data = hub.get("uptime")
+        assert data is not None and "uptime" in data, "uptime not available after upgrade"
+        assert data["uptime"] > 0, f"uptime should be positive, got {data['uptime']}"
+
+        log.info("=== Upgrade test PASSED ===")

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
@@ -49,14 +49,22 @@ REBOOT_WAIT_S = 15
 
 
 def get_auth_token(host, username=DEFAULT_ADMIN_USER, password=DEFAULT_ADMIN_PASS):
-    """Authenticate with the hub's REST API and return a JWT bearer token."""
+    """Authenticate with the hub's REST API and return a JWT bearer token.
+
+    Returns None if security is disabled (FT_SECURITY=0).
+    """
     url = f"http://{host}/rest/signIn"
-    resp = requests.post(url, json={"username": username, "password": password}, timeout=10)
-    resp.raise_for_status()
-    return resp.json()["access_token"]
+    try:
+        resp = requests.post(url, json={"username": username, "password": password}, timeout=10)
+        if resp.status_code == 200 and "access_token" in resp.text:
+            return resp.json()["access_token"]
+    except Exception:
+        pass
+    log.info("Security disabled or signIn unavailable — proceeding without auth")
+    return None
 
 
-def ota_upload(host, firmware_path, token):
+def ota_upload(host, firmware_path, token=None):
     """Upload firmware via OTA and wait for the hub to reboot."""
     url = f"http://{host}/rest/uploadFirmware"
     fw_path = Path(firmware_path)
@@ -65,11 +73,15 @@ def ota_upload(host, firmware_path, token):
     size = fw_path.stat().st_size
     log.info("OTA upload: %s (%d bytes) → %s", fw_path.name, size, host)
 
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
     with open(fw_path, "rb") as f:
         resp = requests.post(
             url,
             files={"file": (fw_path.name, f, "application/octet-stream")},
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             timeout=OTA_TIMEOUT_S,
         )
 

--- a/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
+++ b/USBInsightHub-A1/UIH-ESP32S3/test/integration/test_nvs_upgrade.py
@@ -261,11 +261,11 @@ class TestNvsUpgradeMigration:
         snap_upgraded = snapshot_full_config(hub)
         save_snapshot("post-upgrade", snap_upgraded)
 
-        # Dump NVS binary (requires reboot_enabled on current firmware).
-        # This enables reverting to this exact NVS state if needed.
-        hub.set({"reboot_enabled": 1})
-        time.sleep(0.5)
-        save_nvs_snapshot(hub, "post-upgrade-nvs")
+        # NVS binary dump is available via hub.dump_nvs() but requires
+        # bootloader entry (1200-baud touch) which is unreliable and can
+        # leave the hub unresponsive. Run manually when needed:
+        #   hub.set({"reboot_enabled": 1})
+        #   hub.dump_nvs("snapshots/post-upgrade-nvs.bin")
 
         # ── Step 7: Verify old settings survived ────────────────
         log.info("=== Step 7: Verifying settings survived migration ===")


### PR DESCRIPTION
## Summary
- Add integration tests for NVS config persistence across reboots (`test_nvs_persistence.py`, 13 tests)
- Add upgrade migration test from v1.0.0 blob-based NVS to current key-value NVS (`test_nvs_upgrade.py`, OTA-based)
- **Fix brightness migration bug**: v1.0.0 serial API stored raw percentage (10-100) while menu/defaults and the web API used PWM (50-1000); migration now detects format by range and converts accordingly to PWM. (I'd lean towards persisting as percentage always so it's hardware neutral, but we can manage the conversion when needed.)
- Add `reboot_enabled` config field, `restart` serial action, and `uptime` getter to firmware.  These were WiP from other PRs, but were needed to support the tests. (The other PR is held up with trying to manage entering the bootloader, which isn't needed here.)
- Factor `Hub` class out of `conftest.py` into reusable `hub.py`
- Add `nvs_dump.sh` / `nvs_restore.sh` scripts for manual NVS backup/restore via esptool
- Add shared `brightnessPctToPwm()` / `brightnessPwmToPct()` helpers in `datatypes.h`

## Test plan
- [x] `test_nvs_persistence.py`: 13/13 passed — settings survive reboot on current firmware
- [x] `test_nvs_upgrade.py`: 1/1 passed — v1.0.0 → current migration preserves all settings including brightness
- [x] `pio run -e esp32-s3-uih` builds successfully

Manually testing for verification:

```
# activate python venv
.venv/bin/activate

# install latest dependencies (requests, used to interact with the UIH web API.)
pip install -r requirements.txt 

# run persistence tests
pytest test_nvs_persistence.py -v -s                                                                                                      
                                                                                                                                                      
# run upgrade migration test (requires WiFi for OTA, ~95s):                                                 
.venv/bin/pytest test_nvs_upgrade.py -v -s --host insighthub.local 
  ```

Covers issue #10.